### PR TITLE
sna,uxa: Fix crash in dri3_get_formats

### DIFF
--- a/src/sna/sna_dri3.c
+++ b/src/sna/sna_dri3.c
@@ -387,7 +387,7 @@ static int sna_dri3_get_formats(ScreenPtr screen,
 		goto bail;
 
 	for (size_t index = 0; index < info->formats; index++)
-		*formats[index] = info->format_info[index].format;
+		(*formats)[index] = info->format_info[index].format;
 
 	return TRUE;
 bail:

--- a/src/uxa/intel_dri3.c
+++ b/src/uxa/intel_dri3.c
@@ -150,7 +150,7 @@ static int intel_dri3_get_formats(ScreenPtr screen,
         goto bail;
 
     for (size_t index = 0; index < info->formats; index++)
-        *formats[index] = info->format_info[index].format;
+        (*formats)[index] = info->format_info[index].format;
 
     return TRUE;
 bail:


### PR DESCRIPTION
Bumping SNA to DRI3 v1.2 isn't ready _yet_, however fixing this is.